### PR TITLE
Add client info form and company details

### DIFF
--- a/templates/intro.html
+++ b/templates/intro.html
@@ -24,10 +24,33 @@
         </p>
         <p><strong>Hinweis:</strong> Dieses Tool dient nur zur Orientierung und ersetzt nicht die offizielle Begutachtung durch den Medizinischen Dienst (MD) oder MEDICPROOF.</p>
 
-        <div style="margin-top: 30px;">
-             {# Link to the first module page #}
-            <a href="{{ url_for('module_page', module_id=1) }}" class="btn btn-primary start-btn">Rechner starten</a>
-        </div>
+        <form method="post" action="{{ url_for('start') }}" class="mt-4">
+            <div class="mb-3">
+                <label for="berater_name" class="form-label">Name des Pflegeberaters / der Pflegeberaterin</label>
+                <input type="text" class="form-control" id="berater_name" name="berater_name">
+            </div>
+            <div class="mb-3">
+                <label for="client_name" class="form-label">Name der pflegebedürftigen Person</label>
+                <input type="text" class="form-control" id="client_name" name="client_name">
+            </div>
+            <div class="mb-3">
+                <label for="insurance_number" class="form-label">Krankenversicherungsnummer (optional)</label>
+                <input type="text" class="form-control" id="insurance_number" name="insurance_number">
+            </div>
+            <div class="mb-3">
+                <label for="dob" class="form-label">Geburtsdatum (optional)</label>
+                <input type="date" class="form-control" id="dob" name="dob">
+            </div>
+            <div class="mb-3">
+                <label for="address" class="form-label">Adresse (optional)</label>
+                <input type="text" class="form-control" id="address" name="address">
+            </div>
+            <div class="mb-3">
+                <label for="phone" class="form-label">Telefonnummer (optional)</label>
+                <input type="text" class="form-control" id="phone" name="phone">
+            </div>
+            <button type="submit" class="btn btn-primary start-btn">Rechner starten</button>
+        </form>
     </div>
 </body>
 </html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -32,6 +32,23 @@
             {% endif %}
         {% endwith %}
 
+        <div class="text-center mb-4">
+            <h2>Optimum Pflegeberatung</h2>
+            <p>Verena Campbell - Pflegeberaterin</p>
+            <p><a href="mailto:verena.campbell@optimum-pflegeberatung.de">verena.campbell@optimum-pflegeberatung.de</a></p>
+        </div>
+
+        {% if user_info %}
+        <div class="mb-4">
+            {% if user_info.berater_name %}<p><strong>Berater/in:</strong> {{ user_info.berater_name }}</p>{% endif %}
+            {% if user_info.client_name %}<p><strong>Klient/in:</strong> {{ user_info.client_name }}</p>{% endif %}
+            {% if user_info.insurance_number %}<p><strong>Krankenversicherungsnummer:</strong> {{ user_info.insurance_number }}</p>{% endif %}
+            {% if user_info.dob %}<p><strong>Geburtsdatum:</strong> {{ user_info.dob }}</p>{% endif %}
+            {% if user_info.address %}<p><strong>Adresse:</strong> {{ user_info.address }}</p>{% endif %}
+            {% if user_info.phone %}<p><strong>Telefon:</strong> {{ user_info.phone }}</p>{% endif %}
+        </div>
+        {% endif %}
+
         <h1 class="mb-4 text-center">Ergebnis der Pflegegradberechnung</h1>
 
         <!-- Summary Section -->
@@ -156,6 +173,9 @@
             <script id="pdf-data" type="application/json">
                 {{ results | tojson | safe }}
             </script>
+            <script id="user-info-data" type="application/json">
+                {{ user_info | tojson | safe }}
+            </script>
             <button id="generate-pdf-button" type="button" class="btn btn-success">
                 <i class="bi bi-file-earmark-pdf"></i> Ergebnisse als PDF speichern
             </button>
@@ -170,6 +190,7 @@
     <script>
         document.getElementById('generate-pdf-button').addEventListener('click', function() {
             const resultsDataElement = document.getElementById('pdf-data');
+            const userInfoElement = document.getElementById('user-info-data');
             if (!resultsDataElement) {
                 console.error('PDF data element not found!');
                 alert('Fehler: PDF-Daten nicht gefunden.');
@@ -185,6 +206,15 @@
                 return;
             }
 
+            let userInfo = {};
+            if (userInfoElement) {
+                try {
+                    userInfo = JSON.parse(userInfoElement.textContent);
+                } catch (e) {
+                    console.error('Failed to parse user info:', e);
+                }
+            }
+
             // Prepare the payload EXACTLY as the backend /generate_pdf expects
             const payload = {
                 detailed_results: {
@@ -196,7 +226,8 @@
                 final_total_score: resultsData.final_total_score,
                 pflegegrad: resultsData.pflegegrad,
                 notes: resultsData.notes || {}, // Pass aggregated notes
-                benefits: resultsData.benefits || {} // Pass benefits data
+                benefits: resultsData.benefits || {}, // Pass benefits data
+                user_info: userInfo
             };
 
             console.log('Sending payload to /generate_pdf:', payload); // Debugging


### PR DESCRIPTION
## Summary
- add introductory form for berater and client information
- store user details in session before starting the questionnaire
- display business header and user/client data on results page
- include user info in generated PDF

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68472e2895348331a16f225250ea51f6